### PR TITLE
chore: add plugin directory to pnpm-workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ packages:
   - scripts/*
   - docs
   - playground
+  - apps/web-antdv-next/src/plugins/
 
 overrides:
   '@ast-grep/napi': 'catalog:'


### PR DESCRIPTION
将插件目录添加到pnpm-workspace以支持前端插件自定义依赖