### PR TITLE
chore: ignore local codegraph and playwright mcp dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ vite.config.ts.*
 skills-lock.json
 .atomcode
 datalog
+.codegraph/
+.playwright-mcp/
 
 # 升级 vben 时需要删除的文件(夹)
 .changeset


### PR DESCRIPTION
## Summary
- Ignore `.codegraph/` and `.playwright-mcp/` so local tooling files stay out of the repository.

## Test plan
- [x] Confirm `.gitignore` only adds the two local tooling directories