### PR TITLE
feat: auto-refresh redis and server monitors

### DIFF
--- a/apps/web-antdv-next/src/views/monitor/redis/components/active-series.vue
+++ b/apps/web-antdv-next/src/views/monitor/redis/components/active-series.vue
@@ -19,6 +19,8 @@ const { renderEcharts } = useEcharts(chartRef);
 
 const renderChart = () => {
   renderEcharts({
+    animationDuration: 600,
+    animationDurationUpdate: 600,
     progress: {
       show: true,
     },

--- a/apps/web-antdv-next/src/views/monitor/redis/components/commands-series.vue
+++ b/apps/web-antdv-next/src/views/monitor/redis/components/commands-series.vue
@@ -25,6 +25,8 @@ const labelColor = computed(() =>
 
 const renderChart = () => {
   renderEcharts({
+    animationDuration: 600,
+    animationDurationUpdate: 600,
     series: [
       {
         type: 'pie',

--- a/apps/web-antdv-next/src/views/monitor/redis/index.vue
+++ b/apps/web-antdv-next/src/views/monitor/redis/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 
 import { Page } from '@vben/common-ui';
 import { $t } from '@vben/locales';
@@ -19,7 +19,13 @@ const redisUsedMemory = computed(() => [
   },
 ]);
 
+const fetching = ref(false);
+
 const fetchRedisData = async () => {
+  if (fetching.value) {
+    return;
+  }
+  fetching.value = true;
   loading.value = true;
   try {
     const res = await getRedisMonitorApi();
@@ -28,10 +34,39 @@ const fetchRedisData = async () => {
   } catch (error) {
     console.error(error);
   } finally {
+    fetching.value = false;
     loading.value = false;
   }
 };
-fetchRedisData();
+
+const REFRESH_INTERVAL = 5000;
+let refreshTimer: null | ReturnType<typeof setInterval> = null;
+
+function startAutoRefresh() {
+  stopAutoRefresh();
+  refreshTimer = setInterval(() => {
+    if (document.visibilityState === 'hidden') {
+      return;
+    }
+    fetchRedisData();
+  }, REFRESH_INTERVAL);
+}
+
+function stopAutoRefresh() {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+onMounted(() => {
+  fetchRedisData();
+  startAutoRefresh();
+});
+
+onUnmounted(() => {
+  stopAutoRefresh();
+});
 
 const redisDescriptionItems = computed(() => [
   {
@@ -141,27 +176,23 @@ watch(redisInfo, (val) => {
 </script>
 
 <template>
-  <Page auto-content-height content-class="flex flex-col">
-    <a-card :title="$t('page.monitor.redis.info.title')" :loading="loading">
-      <a-descriptions :items="redisDescriptionItems" />
-    </a-card>
-    <div class="mt-4 flex min-h-0 flex-1 space-x-4">
-      <div class="flex min-h-0 flex-1 flex-col">
+  <Page>
+    <div class="flex flex-col gap-4">
+      <a-card :title="$t('page.monitor.redis.info.title')" :loading="loading">
+        <a-descriptions :items="redisDescriptionItems" />
+      </a-card>
+      <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <a-card
-          class="flex flex-1 flex-col"
           :title="$t('page.monitor.redis.cards.commands.title')"
           :loading="loading"
         >
-          <CommandsSeries class="min-h-0 flex-1" :stats="redisStats" />
+          <CommandsSeries :stats="redisStats" />
         </a-card>
-      </div>
-      <div class="flex min-h-0 flex-1 flex-col">
         <a-card
-          class="flex flex-1 flex-col"
           :title="$t('page.monitor.redis.cards.memory.title')"
           :loading="loading"
         >
-          <ActiveSeries class="min-h-0 flex-1" :memory="redisUsedMemory" />
+          <ActiveSeries :memory="redisUsedMemory" />
         </a-card>
       </div>
     </div>

--- a/apps/web-antdv-next/src/views/monitor/server/index.vue
+++ b/apps/web-antdv-next/src/views/monitor/server/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 
 import { Page } from '@vben/common-ui';
 import { $t } from '@vben/locales';
@@ -77,7 +77,13 @@ const usageStyle = (type: string) => {
   return { color: '#DC143C' };
 };
 
+const fetching = ref(false);
+
 const fetchServerData = async () => {
+  if (fetching.value) {
+    return;
+  }
+  fetching.value = true;
   loading.value = true;
   try {
     const res = await getServerMonitorApi();
@@ -89,6 +95,7 @@ const fetchServerData = async () => {
   } catch (error) {
     console.error(error);
   } finally {
+    fetching.value = false;
     loading.value = false;
   }
 };
@@ -111,14 +118,43 @@ const [Grid, gridApi] = useVbenVxeGrid({
   },
 });
 
-onMounted(async () => {
+const refreshServerData = async () => {
   await fetchServerData();
   gridApi.setGridOptions({ data: diskData.value });
+};
+
+const REFRESH_INTERVAL = 5000;
+let refreshTimer: null | ReturnType<typeof setInterval> = null;
+
+function startAutoRefresh() {
+  stopAutoRefresh();
+  refreshTimer = setInterval(() => {
+    if (document.visibilityState === 'hidden') {
+      return;
+    }
+    refreshServerData();
+  }, REFRESH_INTERVAL);
+}
+
+function stopAutoRefresh() {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+onMounted(() => {
+  refreshServerData();
+  startAutoRefresh();
+});
+
+onUnmounted(() => {
+  stopAutoRefresh();
 });
 </script>
 
 <template>
-  <Page auto-content-height>
+  <Page>
     <div class="grid gap-6 xl:grid-cols-2">
       <div class="min-w-0">
         <a-card :loading="loading" :title="$t('page.monitor.server.cpu.title')">


### PR DESCRIPTION
## Summary
- Refresh Redis and server monitor data every 5 seconds
- Show the existing card skeleton while a refresh is in flight
- Keep Redis chart cards at natural height with page padding

## Test plan
- [x] Redis and server monitor pages typecheck