### PR TITLE
chore: add plugin.toml summary and description

### DIFF
--- a/apps/web-antdv-next/src/plugins/aliyun_sms/plugin.toml
+++ b/apps/web-antdv-next/src/plugins/aliyun_sms/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+summary = 'Aliyun SMS UI'
+version = '0.0.1'
+description = 'fba Aliyun SMS 插件的前端实现'
+author = 'wu-clan'
+tags = ['notification']

--- a/apps/web-antdv-next/src/plugins/code_generator/plugin.toml
+++ b/apps/web-antdv-next/src/plugins/code_generator/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+summary = 'Code Generator UI'
+version = '0.0.1'
+description = 'fba Code Generator 插件的前端实现'
+author = 'wu-clan'
+tags = ['other']

--- a/apps/web-antdv-next/src/plugins/config/plugin.toml
+++ b/apps/web-antdv-next/src/plugins/config/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+summary = 'Config UI'
+version = '0.0.1'
+description = 'fba Config 插件的前端实现'
+author = 'wu-clan'
+tags = ['other']

--- a/apps/web-antdv-next/src/plugins/dict/plugin.toml
+++ b/apps/web-antdv-next/src/plugins/dict/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+summary = 'Dict UI'
+version = '0.0.1'
+description = 'fba Dict 插件的前端实现'
+author = 'wu-clan'
+tags = ['other']

--- a/apps/web-antdv-next/src/plugins/email/plugin.toml
+++ b/apps/web-antdv-next/src/plugins/email/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+summary = 'Email UI'
+version = '0.0.1'
+description = 'fba Email 插件的前端实现'
+author = 'wu-clan'
+tags = ['other']

--- a/apps/web-antdv-next/src/plugins/notice/plugin.toml
+++ b/apps/web-antdv-next/src/plugins/notice/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+summary = 'Notice UI'
+version = '0.0.1'
+description = 'fba Notice 插件的前端实现'
+author = 'wu-clan'
+tags = ['other']

--- a/apps/web-antdv-next/src/plugins/oauth2/plugin.toml
+++ b/apps/web-antdv-next/src/plugins/oauth2/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+summary = 'OAuth2 UI'
+version = '0.0.1'
+description = 'fba OAuth2 插件的前端实现'
+author = 'wu-clan'
+tags = ['auth']


### PR DESCRIPTION
## Summary
- Add `plugin.toml` for bundled frontend plugins
- Set summary to `{Backend} UI` and description to `fba {Backend} 插件的前端实现`

## Test plan
- [x] Bundled plugins now have plugin manifests